### PR TITLE
Immortal Guardian

### DIFF
--- a/scripts/northrend/ulduar/ulduar/boss_yogg_saron.cpp
+++ b/scripts/northrend/ulduar/ulduar/boss_yogg_saron.cpp
@@ -1329,6 +1329,14 @@ struct npc_immortal_guardianAI : public ScriptedAI
         m_uiDrainLifeTimer = 10000;
         m_bWeakened = false;
     }
+    
+    void AttackStart(Unit* pWho) override
+    {
+        if (pWho->GetEntry() == NPC_THORIM_HELPER)
+            return;
+
+        ScriptedAI::AttackStart(pWho);
+    }
 
     void DamageTaken(Unit* pDealer, uint32& uiDamage) override
     {


### PR DESCRIPTION
Immortal Guardian should not attack Thorim, but the attack. This fix corrects the situation. Because of falling on it Storm Titans, called aggro on Thorim.